### PR TITLE
Make auth persist across refreshes

### DIFF
--- a/client/src/Backend.ts
+++ b/client/src/Backend.ts
@@ -2,96 +2,93 @@ import Business from './types/business'
 import User from './types/user'
 import axios from 'axios'
 
-export default class Backend {
-  private baseUrl: string
+const baseUrl = 'http://localhost:8000'
 
-  constructor(baseUrl: string) {
-    this.baseUrl = baseUrl
-  }
+function getAuthToken(): string|undefined {
+  return localStorage.authToken
+}
 
-  private get authToken(): string|undefined {
-    return localStorage.authToken
-  }
-
-  private set authToken(token: string|undefined) {
+function setAuthToken(token: string|undefined): void {
+  if (token === undefined) {
+    delete localStorage.authToken
+  } else {
     localStorage.authToken = token
   }
+}
 
-  static hasAuthToken(): boolean {
-    return !!localStorage.authToken
-  }
+export function hasAuthToken(): boolean {
+  return !!localStorage.authToken
+}
 
-  async signup(user: User, password: string): Promise<void> {
-    const url = `${this.baseUrl}/user/register`
+export async function signup(user: User, password: string): Promise<void> {
+  const url = `${baseUrl}/user/register`
 
-    try {
-      const response = await axios.post(url, {
-        firstName: user.firstName,
-        lastName: user.lastName,
-        username: user.username,
-        email: user.email,
-        password: password,
-      })
+  try {
+    const response = await axios.post(url, {
+      firstName: user.firstName,
+      lastName: user.lastName,
+      username: user.username,
+      email: user.email,
+      password: password,
+    })
 
-      this.authToken = response.data.authToken
-    } catch (err) {
-      if (err.response && err.response.status === 409) {
-        throw new Error('UsernameTaken')
-      }
-
-      console.error('unexpected error registering user', err)
-      throw new Error('SignupFailed')
+    setAuthToken(response.data.authToken)
+  } catch (err) {
+    if (err.response && err.response.status === 409) {
+      throw new Error('UsernameTaken')
     }
+
+    console.error('unexpected error registering user', err)
+    throw new Error('SignupFailed')
   }
+}
 
-  async login(username: string, password: string): Promise<void> {
-    const url = `${this.baseUrl}/user/login`
+export async function login(username: string, password: string): Promise<void> {
+  const url = `${baseUrl}/user/login`
 
-    try {
-      const response = await axios.post(url, {username, password})
-
-      this.authToken = response.data.authToken
-    } catch (err) {
-      if (err.response) {
-        switch (err.response.status) {
-        case 404:
-          throw new Error('UserNotFound')
-        case 401:
-          throw new Error('IncorrectPassword')
-        }
+  try {
+    const response = await axios.post(url, {username, password})
+    setAuthToken(response.data.authToken)
+  } catch (err) {
+    if (err.response) {
+      switch (err.response.status) {
+      case 404:
+        throw new Error('UserNotFound')
+      case 401:
+        throw new Error('IncorrectPassword')
       }
-
-      console.error('unexpected error logging user in', err)
-      throw new Error('LoginFailed')
     }
+
+    console.error('unexpected error logging user in', err)
+    throw new Error('LoginFailed')
   }
+}
 
-  async registerBusiness(business: Business): Promise<void> {
-    const url = `${this.baseUrl}/business/register`
-    try {
-      await axios.post(url, {
-        name: business.name,
-        handle: business.handle,
-        email: business.email,
-        website: business.website,
-        description: business.description,
-        logo: business.logo,
-      }, {
-        headers: {
-          Authorization: `Bearer ${this.authToken}`,
-        },
-      })
+export async function registerBusiness(business: Business): Promise<void> {
+  const url = `${baseUrl}/business/register`
+  try {
+    await axios.post(url, {
+      name: business.name,
+      handle: business.handle,
+      email: business.email,
+      website: business.website,
+      description: business.description,
+      logo: business.logo,
+    }, {
+      headers: {
+        Authorization: `Bearer ${getAuthToken()}`,
+      },
+    })
+  }
+  catch (err) {
+    if (err.response.data.error === 'BusinessNameTaken') {
+      throw new Error('BusinessNameTaken')
     }
-    catch (err) {
-      if (err.response.data.error === 'BusinessNameTaken') {
-        throw new Error('BusinessNameTaken')
-      }
-      else if (err.response.data.error === 'BusinessHandleTaken') {
-        throw new Error('BusinessHandleTaken')
-      }
-      else {
-        throw new Error('Sorry, an unexpected error occurred. Please try again later.')
-      }
+    else if (err.response.data.error === 'BusinessHandleTaken') {
+      throw new Error('BusinessHandleTaken')
+    }
+    else {
+      throw new Error('Sorry, an unexpected error occurred. Please try again later.')
     }
   }
 }

--- a/client/src/Backend.ts
+++ b/client/src/Backend.ts
@@ -3,11 +3,22 @@ import User from './types/user'
 import axios from 'axios'
 
 export default class Backend {
-  baseUrl: string
-  authToken?: string
+  private baseUrl: string
 
   constructor(baseUrl: string) {
     this.baseUrl = baseUrl
+  }
+
+  private get authToken(): string|undefined {
+    return localStorage.authToken
+  }
+
+  private set authToken(token: string|undefined) {
+    localStorage.authToken = token
+  }
+
+  static hasAuthToken(): boolean {
+    return !!localStorage.authToken
   }
 
   async signup(user: User, password: string): Promise<void> {

--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -9,24 +9,21 @@ import {
 import PrivateRoute from './PrivateRoute'
 import Login from './Login'
 import '../styles/index.scss'
-import Backend from '../Backend'
 import BusinessRegistration from './BusinessRegistration'
 import Signup from './Signup'
-
-const backend = new Backend('http://localhost:8000')
 
 const AppRoutes = () => {
   return (
     <Switch>
       <Redirect exact from="/" to="/home" />
       <Route exact path='/signup'>
-        <Signup backend={backend} />
+        <Signup />
       </Route>
       <Route exact path='/login'>
-        <Login backend={backend}/>
+        <Login />
       </Route>
       <PrivateRoute exact path='/business/register'>
-        <BusinessRegistration backend={backend}/>
+        <BusinessRegistration />
       </PrivateRoute>
       <PrivateRoute exact path='/home'>
         <Link to='/home/user'>

--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
-import { BrowserRouter, Switch, Route, Link } from 'react-router-dom'
+import {
+  BrowserRouter,
+  Switch,
+  Route,
+  Link,
+  Redirect,
+} from 'react-router-dom'
+import PrivateRoute from './PrivateRoute'
 import Login from './Login'
 import '../styles/index.scss'
 import Backend from '../Backend'
@@ -11,16 +18,17 @@ const backend = new Backend('http://localhost:8000')
 const AppRoutes = () => {
   return (
     <Switch>
+      <Redirect exact from="/" to="/home" />
       <Route exact path='/signup'>
         <Signup backend={backend} />
       </Route>
-      <Route exact path='/'>
+      <Route exact path='/login'>
         <Login backend={backend}/>
       </Route>
-      <Route exact path='/business/register'>
+      <PrivateRoute exact path='/business/register'>
         <BusinessRegistration backend={backend}/>
-      </Route>
-      <Route exact path='/home'>
+      </PrivateRoute>
+      <PrivateRoute exact path='/home'>
         <Link to='/home/user'>
           user portfolio
         </Link>
@@ -28,7 +36,7 @@ const AppRoutes = () => {
         <Link to='/business/register'>
           register business
         </Link>
-      </Route>
+      </PrivateRoute>
       <Route path='*'>
         404 Not Found
       </Route>

--- a/client/src/components/BusinessRegistration.tsx
+++ b/client/src/components/BusinessRegistration.tsx
@@ -2,11 +2,9 @@ import React, {useState} from 'react'
 import LabeledInput from './LabeledInput'
 import FileUpload from './FileUpload'
 import '../styles/business-registration.scss'
-import Backend from 'Backend'
+import {registerBusiness} from '../Backend'
 
-interface Props {backend: Backend}
-
-const BusinessRegistration: React.FC<Props> = ({backend}: Props) => {
+const BusinessRegistration: React.FC = () => {
   const [name, setName] = useState<string>('')
   const [handle, setHandle] = useState<string>('')
   const [email, setEmail] = useState<string>('')
@@ -43,7 +41,7 @@ const BusinessRegistration: React.FC<Props> = ({backend}: Props) => {
     }
 
     try {
-      await backend.registerBusiness(business)
+      await registerBusiness(business)
       // TODO: navigate to business page instead of alerting
       alert('Business registered!')
     } catch (err) {

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -2,11 +2,9 @@ import React, { useEffect, useState } from 'react'
 import { Link, useHistory } from 'react-router-dom'
 import LabeledInput from './LabeledInput'
 import '../styles/Login.scss'
-import Backend from '../Backend'
+import {login, hasAuthToken} from '../Backend'
 
-interface Props {backend: Backend}
-
-const Login: React.FC<Props> = ({backend}: Props) => {
+const Login: React.FC = () => {
   const history = useHistory()
   const [username, setUsername] = useState<string>('')
   const [password, setPassword] = useState<string>('')
@@ -14,7 +12,7 @@ const Login: React.FC<Props> = ({backend}: Props) => {
   const [passwordErr, setPasswordErr] = useState<string>('')
 
   useEffect(() => {
-    if (Backend.hasAuthToken()) {
+    if (hasAuthToken()) {
       history.replace('/')
     }
   }, [])
@@ -23,7 +21,7 @@ const Login: React.FC<Props> = ({backend}: Props) => {
     event.preventDefault()
 
     try {
-      await backend.login(username, password)
+      await login(username, password)
       history.push('/home')
     } catch (err) {
       switch(err.message) {

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Link, useHistory } from 'react-router-dom'
 import LabeledInput from './LabeledInput'
 import '../styles/Login.scss'
@@ -12,6 +12,12 @@ const Login: React.FC<Props> = ({backend}: Props) => {
   const [password, setPassword] = useState<string>('')
   const [usernameErr, setUsernameErr] = useState<string>('')
   const [passwordErr, setPasswordErr] = useState<string>('')
+
+  useEffect(() => {
+    if (Backend.hasAuthToken()) {
+      history.replace('/')
+    }
+  }, [])
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault()

--- a/client/src/components/PrivateRoute.tsx
+++ b/client/src/components/PrivateRoute.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import {Route, RouteProps, Redirect} from 'react-router-dom'
-import Backend from '../Backend'
+import {hasAuthToken} from '../Backend'
 
 const PrivateRoute: React.FC<React.PropsWithChildren<RouteProps>> = (
   {children, ...rest}: React.PropsWithChildren<RouteProps>,
 ) => {
   return <Route {...rest} render={({location}) => {
-    if (Backend.hasAuthToken()) {
+    if (hasAuthToken()) {
       return children
     } else {
       return (

--- a/client/src/components/PrivateRoute.tsx
+++ b/client/src/components/PrivateRoute.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import {Route, RouteProps, Redirect} from 'react-router-dom'
+import Backend from '../Backend'
+
+const PrivateRoute: React.FC<React.PropsWithChildren<RouteProps>> = (
+  {children, ...rest}: React.PropsWithChildren<RouteProps>,
+) => {
+  return <Route {...rest} render={({location}) => {
+    if (Backend.hasAuthToken()) {
+      return children
+    } else {
+      return (
+        <Redirect to={{
+          pathname: '/login',
+          state: {from: location},
+        }}/>
+      )
+    }
+  }} />
+}
+
+export default PrivateRoute

--- a/client/src/components/Signup.tsx
+++ b/client/src/components/Signup.tsx
@@ -2,11 +2,9 @@ import React, { FormEvent, useEffect, useState }from 'react'
 import { Link, useHistory } from 'react-router-dom'
 import LabeledInput from './LabeledInput'
 import '../styles/Signup.scss'
-import Backend from '../Backend'
+import {signup} from '../Backend'
 
-interface Props {backend: Backend}
-
-const Signup: React.FC<Props> = ({backend}: Props) => {
+const Signup: React.FC = () => {
   const history = useHistory()
   const [firstName, setFirstName] = useState<string>('')
   const [lastName, setLastName] = useState<string>('')
@@ -29,7 +27,7 @@ const Signup: React.FC<Props> = ({backend}: Props) => {
     e.preventDefault()
 
     try {
-      await backend.signup({firstName, lastName, username, email}, password)
+      await signup({firstName, lastName, username, email}, password)
       history.push('/business/register')
     } catch (err) {
       if (err.message === 'UsernameTaken') {


### PR DESCRIPTION
The app now saves the auth token in the browsers local storage. If there's on auth token, then any routes that require auth redirect to the login page. If there is an auth token, then the login page redirects to the home page.